### PR TITLE
overlay: allow to test a FUSE implementation of overlay

### DIFF
--- a/README
+++ b/README
@@ -38,6 +38,10 @@ To run these tests:
 
      The first M rotations will create a new filesystem as the upper layer.
 
+     To run the tests using a different file system type:
+
+	./run --fs=<fs-type>
+
 
 For more advanced overlayfs test options and more examples, see:
      https://github.com/amir73il/overlayfs/wiki/Overlayfs-testing

--- a/mount_union.py
+++ b/mount_union.py
@@ -39,8 +39,7 @@ def mount_union(ctx):
         os.mkdir(workdir)
 
         mntopt = " -orw" + cfg.mntopts()
-        system("mount -t overlay overlay " + union_mntroot + mntopt +
-               ",lowerdir=" + lower_mntroot + ",upperdir=" + upperdir + ",workdir=" + workdir)
+        system(("mount -t %s overlay " % cfg.fs()) + union_mntroot + mntopt + ",lowerdir=" + lower_mntroot + ",upperdir=" + upperdir + ",workdir=" + workdir)
         ctx.note_upper_fs(upper_mntroot, testdir)
         ctx.note_lower_layers(lower_mntroot)
         ctx.note_upper_layer(upperdir)

--- a/remount_union.py
+++ b/remount_union.py
@@ -29,7 +29,7 @@ def remount_union(ctx, rotate_upper=False):
 
         mnt = union_mntroot
         mntopt = " -orw" + cfg.mntopts()
-        cmd = "mount -t overlay overlay " + mnt + mntopt + ",lowerdir=" + lowerlayers + ",upperdir=" + upperdir + ",workdir=" + workdir
+        cmd = ("mount -t %s overlay " % cfg.fs()) + mnt + mntopt + ",lowerdir=" + lowerlayers + ",upperdir=" + upperdir + ",workdir=" + workdir
         system(cmd)
         if cfg.is_verbose():
             write_kmsg(cmd);

--- a/run
+++ b/run
@@ -14,8 +14,8 @@ def show_format(why):
     if why:
         print(why)
     print("Format:")
-    print("\t", sys.argv[0], "<--no|--ov[=<maxlayers>]> [--samefs|--maxfs=<maxfs>|--squashfs] [--xdev] [--verify] [--ts=<0|1>] [-v] [<test-name>+]")
-    print("\t", sys.argv[0], "<--no|--ov> [--samefs|--squashfs] [-s|--set-up]")
+    print("\t", sys.argv[0], "<--no|--ov[=<maxlayers>]> [--fs=<type>] [--samefs|--maxfs=<maxfs>|--squashfs] [--xdev] [--verify] [--ts=<0|1>] [-v] [<test-name>+]")
+    print("\t", sys.argv[0], "<--no|--ov> [--fs=<type>] [--samefs|--squashfs] [-s|--set-up]")
     print("\t", sys.argv[0], "--open-file <file> [-acdertvw] [-W <data>] [-R <data>] [-B] [-E <err>]")
     print("\t", sys.argv[0], "--<fsop> <file> [<args>*] [-aLlv] [-R <content>] [-B] [-E <err>]")
     sys.exit(2)
@@ -119,6 +119,13 @@ if cfg.testing_overlayfs():
 # maxfs 0 means one upper fs and one lower fs
 maxfs = 0
 args = args[1:]
+
+if len(args) > 0 and args[0].startswith("--fs="):
+    s = args[0]
+    t = s[s.rfind("=")+1:]
+    cfg.set_fs(t)
+    args = args[1:]
+
 if len(args) > 0 and (args[0] == "--samefs" or args[0] == "--squashfs" or args[0].startswith("--maxfs=")):
     if args[0] == "--samefs":
         # maxfs < 0 means samefs

--- a/settings.py
+++ b/settings.py
@@ -35,6 +35,7 @@ class config:
         self.__squashfs = False
         self.__xino = False
         self.__mntopts = ""
+        self.__fs = "overlay"
 
     def progname(self):
         return self.__progname
@@ -100,3 +101,8 @@ class config:
         self.__mntopts = opts
     def mntopts(self):
         return self.__mntopts
+
+    def fs(self):
+        return self.__fs
+    def set_fs(self, to):
+        self.__fs = to


### PR DESCRIPTION
we are working on a FUSE implementation (https://github.com/containers/fuse-overlayfs) of overlayfs so that it can be used by rootless containers once Linux 4.18 is out, as it is possible to mount a FUSE file system in an user namespace.

These changes are required in order to test this implementation.

