### PR TITLE
Fix invocations of `cfg.is_nested`

### DIFF
--- a/run
+++ b/run
@@ -107,7 +107,7 @@ else:
 args = args[1:]
 
 if len(args) > 0 and args[0].startswith("--fuse="):
-    if not cfg.testing_overlayfs() or cfg.is_nested:
+    if not cfg.testing_overlayfs() or cfg.is_nested():
         show_format("--fuse requires --ov")
     s = args[0]
     t = s[s.rfind("=")+1:]

--- a/unmount_union.py
+++ b/unmount_union.py
@@ -10,7 +10,7 @@ def unmount_union(ctx):
             system("umount " + cfg.base_mntroot())
             check_not_tainted()
         # unmount individual layers with maxfs > 0
-        if cfg.maxfs() > 0 or cfg.is_nested:
+        if cfg.maxfs() > 0 or cfg.is_nested():
             try:
                 system("umount " + cfg.upper_mntroot() + "/* 2>/dev/null")
             except RuntimeError:


### PR DESCRIPTION
This function was used without `()` in a few places, hence it evaluated to `True` instead of the actual check.