### PR TITLE
Add support for lower erofs

### DIFF
--- a/run
+++ b/run
@@ -14,8 +14,8 @@ def show_format(why):
     if why:
         print(why)
     print("Format:")
-    print("\t", sys.argv[0], "<--no|--ov|--ovov>[=<maxlayers>] [--fuse=<subtype>] [--samefs|--maxfs=<maxfs>|--squashfs] [--xdev] [--xino] [--meta] [--verify] [--ts=<0|1>] [-v] [<test-name>+]")
-    print("\t", sys.argv[0], "<--no|--ov|--ovov> [--fuse=<subtype>] [--samefs|--squashfs] [-s|--set-up]")
+    print("\t", sys.argv[0], "<--no|--ov|--ovov>[=<maxlayers>] [--fuse=<subtype>] [--samefs|--maxfs=<maxfs>|--squashfs|--erofs] [--xdev] [--xino] [--meta] [--verify] [--ts=<0|1>] [-v] [<test-name>+]")
+    print("\t", sys.argv[0], "<--no|--ov|--ovov> [--fuse=<subtype>] [--samefs|--squashfs|--erofs] [-s|--set-up]")
     print("\t", sys.argv[0], "[-c|--clean-up]")
     print("\t", sys.argv[0], "--open-file <file> [-acdertvw] [-W <data>] [-R <data>] [-B] [-E <err>]")
     print("\t", sys.argv[0], "--<fsop> <file> [<args>*] [-aLlv] [-R <content>] [-B] [-E <err>]")
@@ -147,7 +147,7 @@ elif cfg.testing_overlayfs():
         cfg.set_metacopy()
 
 maxfs = cfg.maxfs()
-if len(args) > 0 and (args[0] == "--samefs" or args[0] == "--squashfs" or args[0].startswith("--maxfs=")):
+if len(args) > 0 and (args[0] == "--samefs" or args[0] == "--squashfs" or args[0] == "--erofs" or args[0].startswith("--maxfs=")):
     if args[0] == "--samefs":
         # maxfs < 0 means samefs
         maxfs = -1
@@ -157,6 +157,10 @@ if len(args) > 0 and (args[0] == "--samefs" or args[0] == "--squashfs" or args[0
         # maxfs 0 means one upper fs and one lower fs
         maxfs = 0
         cfg.set_squashfs()
+    elif args[0] == "--erofs":
+        # maxfs 0 means one upper fs and one lower fs
+        maxfs = 0
+        cfg.set_erofs()
     elif args[0].startswith("--maxfs="):
         s = args[0]
         n = s[s.rfind("=")+1:]

--- a/set_up.py
+++ b/set_up.py
@@ -185,6 +185,13 @@ def set_up(ctx):
         system("mksquashfs " + lowerdir + " " + lowerimg + " -keep-as-directory > /dev/null");
         system("mount -o loop,ro " + lowerimg + " " + lower_mntroot)
         system("mount --make-private " + lower_mntroot)
+    if cfg.is_erofs():
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            system("cp -fR " + lowerdir + " " + tmpdirname)
+            system("mkfs.erofs " + lowerimg + " " + tmpdirname + " > /dev/null");
+        system("mount -t erofs -o loop,ro " + lowerimg + " " + lower_mntroot)
+        system("mount --make-private " + lower_mntroot)
     elif cfg.should_mount_lower_ro():
         # Make overlay lower layer read-only
         system("mount -o remount,ro " + lower_mntroot)

--- a/settings.py
+++ b/settings.py
@@ -55,6 +55,7 @@ class config:
         self.__verbose = False
         self.__verify = False
         self.__squashfs = False
+        self.__erofs = False
         self.__metacopy = False
         self.__nested = False
         self.__xino = False
@@ -156,6 +157,10 @@ class config:
         self.__squashfs = to
     def is_squashfs(self):
         return self.__squashfs
+    def set_erofs(self, to=True):
+        self.__erofs = to
+    def is_erofs(self):
+        return self.__erofs
     def set_xino(self, to=True):
         self.__xino = to
     def is_xino(self):


### PR DESCRIPTION
Similar to --squashfs, with new run flag --erofs, test files are
packaged to a erofs image and used as the lower layer.

Tested with the latest mkfs.erofs 1.4.

Signed-off-by: Gao Xiang \<hsiangkao@linux.alibaba.com\>